### PR TITLE
Mindlabor/settings bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swifter_remapper",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A framework for Beat Saber map scripting.",
   "main": "./dist/main.js",
   "typings": "dist/main.d.ts",

--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -153,7 +153,6 @@ export class Difficulty {
      * @param {Any} value The value of the setting, leave blank to remove setting.
      */
     setSetting(setting: string, value: any = undefined) {
-        //console.log("hi", this.settings);
         this.updateSets(this.settings, setting, value);
     }
 
@@ -172,9 +171,9 @@ export class Difficulty {
     get diffSetName(): string { return jsonGet(this.diffSet, "_beatmapCharacteristicName") }
     get name(): string { return jsonGet(this.diffSetMap, "_difficulty") }
     get diffRank(): number { return jsonGet(this.diffSetMap, "_difficultyRank") }
-    get requirements(): string[] { return jsonGet(this.diffSetMap, "_customData._requirements") }
-    get suggestions(): string[] { return jsonGet(this.diffSetMap, "_customData._suggestions") }
-    get settings(): string[] { return jsonGet(this.diffSetMap, "_customData._settings", true) }
+    get requirements(): string[] { return jsonGet(this.diffSetMap, "_customData._requirements", []) }
+    get suggestions(): string[] { return jsonGet(this.diffSetMap, "_customData._suggestions", []) }
+    get settings(): any { return jsonGet(this.diffSetMap, "_customData._settings", {}) }
     get warnings(): string[] { return jsonGet(this.diffSetMap, "_customData._warnings") }
     get information(): string[] { return jsonGet(this.diffSetMap, "_customData._information") }
     get label(): string { return jsonGet(this.diffSetMap, "_customData._difficultyLabel") }
@@ -196,7 +195,7 @@ export class Difficulty {
     set diffRank(value: number) { this.updateSets(this.diffSetMap, "_difficultyRank", value) }
     set requirements(value: string[]) { this.updateSets(this.diffSetMap, "_customData._requirements", value) }
     set suggestions(value: string[]) { this.updateSets(this.diffSetMap, "_customData._suggestions", value) }
-    set settings(value: string[]) { this.updateSets(this.diffSetMap, "_customData._settings", value) }
+    set settings(value: any) { this.updateSets(this.diffSetMap, "_customData._settings", value) }
     set warnings(value: string[]) { this.updateSets(this.diffSetMap, "_customData._warnings", value) }
     set information(value: string[]) { this.updateSets(this.diffSetMap, "_customData._information", value) }
     set label(value: string) { this.updateSets(this.diffSetMap, "_customData._difficultyLabel", value) }

--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -150,9 +150,10 @@ export class Difficulty {
     /**
      * Set a setting.
      * @param {String} setting The path of the setting.
-     * @param {*} value The value of the setting, leave blank to remove setting.
+     * @param {Any} value The value of the setting, leave blank to remove setting.
      */
-    setSetting(setting: string, value = undefined) {
+    setSetting(setting: string, value: any = undefined) {
+        //console.log("hi", this.settings);
         this.updateSets(this.settings, setting, value);
     }
 
@@ -173,7 +174,7 @@ export class Difficulty {
     get diffRank(): number { return jsonGet(this.diffSetMap, "_difficultyRank") }
     get requirements(): string[] { return jsonGet(this.diffSetMap, "_customData._requirements") }
     get suggestions(): string[] { return jsonGet(this.diffSetMap, "_customData._suggestions") }
-    get settings(): string[] { return jsonGet(this.diffSetMap, "_customData._settings") }
+    get settings(): string[] { return jsonGet(this.diffSetMap, "_customData._settings", true) }
     get warnings(): string[] { return jsonGet(this.diffSetMap, "_customData._warnings") }
     get information(): string[] { return jsonGet(this.diffSetMap, "_customData._information") }
     get label(): string { return jsonGet(this.diffSetMap, "_customData._difficultyLabel") }

--- a/src/general.ts
+++ b/src/general.ts
@@ -347,16 +347,40 @@ export function jsonPrune(obj: object) {
 * Get a property of an object.
 * @param {Object} obj 
 * @param {String} prop
-* @param {*} init Optional value to initialize the property if it doesn't exist yet.
+* @param {boolean?} init Optional value to initialize the property if it doesn't exist yet.
 */
-export function jsonGet(obj: object, prop: string) {
+export function jsonGet(obj: object, prop: string, init?: boolean) {
+
+    // If the property doesn't exist, initialize it.
+    if (init) jsonFill(obj, prop);
+    
+    // Fetch the property based on the path/prop.
     const steps = prop.split('.')
     let currentObj = obj
     for (let i = 0; i < steps.length - 1; i++) {
         currentObj = currentObj[steps[i]]
         if (currentObj === undefined) return;
     }
+
+    // Return the needed property.
     return currentObj[steps[steps.length - 1]];
+}
+
+/**
+* Fill the object with empty properties along the path of prop.
+* @param {Object} obj 
+* @param {String} prop
+*/
+export function jsonFill(obj: object, prop: string) {
+    const steps = prop.split('.');
+
+    // Create empty objects along the path
+    const nestedObject = [...steps]
+        .reverse()
+        .reduce((prev, current) => ( {[current]: {...prev}} ), {});
+    
+    // Merge the original object into the nested object (if the original object is empty, it will just take the nested object)
+    obj[steps[0]] = Object.assign({}, nestedObject[steps[0]], obj[steps[0]]);
 }
 
 /**

--- a/src/general.ts
+++ b/src/general.ts
@@ -368,8 +368,9 @@ export function jsonGet(obj: object, prop: string, init?: any) {
 
 /**
 * Fill the object with empty properties along the path of prop.
-* @param {Object} obj 
+* @param {Object} obj
 * @param {String} prop
+* @param {Any} value
 */
 export function jsonFill(obj: object, prop: string, value: any) {
     const steps = prop.split('.');

--- a/src/general.ts
+++ b/src/general.ts
@@ -347,12 +347,12 @@ export function jsonPrune(obj: object) {
 * Get a property of an object.
 * @param {Object} obj 
 * @param {String} prop
-* @param {boolean?} init Optional value to initialize the property if it doesn't exist yet.
+* @param {Any?} init Optional value to initialize the property if it doesn't exist yet.
 */
-export function jsonGet(obj: object, prop: string, init?: boolean) {
+export function jsonGet(obj: object, prop: string, init?: any) {
 
     // If the property doesn't exist, initialize it.
-    if (init) jsonFill(obj, prop);
+    if (init != null) jsonFill(obj, prop, init);
     
     // Fetch the property based on the path/prop.
     const steps = prop.split('.')
@@ -371,13 +371,15 @@ export function jsonGet(obj: object, prop: string, init?: boolean) {
 * @param {Object} obj 
 * @param {String} prop
 */
-export function jsonFill(obj: object, prop: string) {
+export function jsonFill(obj: object, prop: string, value: any) {
     const steps = prop.split('.');
 
     // Create empty objects along the path
     const nestedObject = [...steps]
         .reverse()
-        .reduce((prev, current) => ( {[current]: {...prev}} ), {});
+        .reduce((prev, current, i) => {
+            return i === 0? { [current]: value } : { [current]: prev };
+        }, {});
     
     // Merge the original object into the nested object (if the original object is empty, it will just take the nested object)
     obj[steps[0]] = Object.assign({}, nestedObject[steps[0]], obj[steps[0]]);


### PR DESCRIPTION
I was working on the #5 Issue, saw that you had already fixed it but decided to continue on my fix as I was already pretty far.

This should fix the more general issue of `jsonGet` throwing `undefined` whenever it didn't find the json value. This can cause a lot of issues when the json is incomplete at start. 

If your diff json doesn't have the `_customData` key, then `diff.requirements`, `diff.suggestions` and `diff.settings` (and most likely a few other properties) will be `undefined`. This will cause unexpected `Cannot read properties of undefined` errors. 

This solution completes non-existent json properties, which should prevent these kindof problems. 