### PR TITLE
Rework how files are collected and upload to quest

### DIFF
--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -801,6 +801,8 @@ export function exportZip(excludeDiffs: FILENAME<DIFFS>[] = [], zipName?: string
 
 /**
  * Automatically upload the map files to quest, including only necessary files.
+ * 
+ * They will be uploaded to the song WIP folder, {@link QUEST_CUSTOMS_WIP_LEVELS_PATH}
  * @param excludeDiffs Difficulties to exclude.
  * @param options Options to pass to ADB
  */

--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -818,11 +818,15 @@ export async function exportToQuest(excludeDiffs: FILENAME<DIFFS>[] = [], option
     const files = collectBeatmapFiles(excludeDiffs); // surround with quotes for safety
     const cwd = Deno.cwd();
     
+    const questSongFolder = `${QUEST_CUSTOMS_WIP_LEVELS_PATH}/${info.name}`;
+
+    await adbDeno.mkdir(questSongFolder);
+
     const tasks = files.map(v => {
         const relativePath = path.relative(cwd, v);
         console.log(`Uploading ${relativePath} to quest`)
         adbDeno.uploadFile(
-          `${QUEST_CUSTOMS_WIP_LEVELS_PATH}/${relativePath}`,
+          `${questSongFolder}/${relativePath}`,
             v,
           options
         );

--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -732,12 +732,8 @@ export function collectBeatmapFiles(
 ) {
     if (!info.json) throw new Error("The Info object has not been loaded.");
 
-    const absoluteInfoFileName =
-        info.fileName === "Info.dat"
-            ? Deno.cwd() + `\\${info.fileName}`
-            : info.fileName;
     const exportInfo = copy(info.json);
-    let unsanitizedFiles: (string | undefined)[] = [
+    const unsanitizedFiles: (string | undefined)[] = [
         exportInfo._songFilename,
         exportInfo._coverImageFilename,
     ];
@@ -765,13 +761,6 @@ export function collectBeatmapFiles(
             s--;
         }
     }
-    
-
-    const tempDir = Deno.makeTempDirSync();
-    const tempInfo = tempDir + `\\Info.dat`;
-    unsanitizedFiles.push(tempInfo);
-    Deno.writeTextFileSync(tempInfo, JSON.stringify(exportInfo, null, 0));
-
 
     const workingDir = Deno.cwd();
     const files = unsanitizedFiles
@@ -780,7 +769,11 @@ export function collectBeatmapFiles(
         .filter(v => fs.existsSync(v)) // ensure file exists
         
 
+    const tempDir = Deno.makeTempDirSync();
+    const tempInfo = tempDir + `\\Info.dat`;
+    Deno.writeTextFileSync(tempInfo, JSON.stringify(exportInfo, null, 0));
 
+    files.push(tempInfo); // add temp info
 
     return files;
 }

--- a/src/beatmap.ts
+++ b/src/beatmap.ts
@@ -10,7 +10,6 @@ import { AnimationInternals, RawKeyframesAny } from './animation.ts';
 import { OptimizeSettings } from './anim_optimizer.ts';
 import { ENV_NAMES, MODS, settingsHandler, DIFFS, FILENAME, FILEPATH, QUEST_CUSTOMS_WIP_LEVELS_PATH } from './constants.ts';
 import { BoostEvent, BPMChange, LightEvent, LightEventBox, LightEventBoxGroup, LightRotation, LightRotationBox, LightRotationBoxGroup, RotationEvent } from './event.ts';
-import { InvokeADBOptions } from 'https://deno.land/x/adb_deno@0.1.1/setup.ts';
 
 type PostProcessFn<T> = (object: T, diff: Difficulty) => void;
 
@@ -801,11 +800,11 @@ export function exportZip(excludeDiffs: FILENAME<DIFFS>[] = [], zipName?: string
 }
 
 /**
- * Automatically zip the map, including only necessary files.
+ * Automatically upload the map files to quest, including only necessary files.
  * @param excludeDiffs Difficulties to exclude.
- * @param zipName Name of the zip (don't include ".zip"). Uses folder name if undefined.
+ * @param options Options to pass to ADB
  */
-export async function exportToQuest(excludeDiffs: FILENAME<DIFFS>[] = [], options?: InvokeADBOptions) {
+export async function exportToQuest(excludeDiffs: FILENAME<DIFFS>[] = [], options?: adbDeno.InvokeADBOptions) {
     const adbBinary = adbDeno.getADBBinary(adbDeno.defaultADBPath())
 
     // Download ADB

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@ import { Difficulty } from "./beatmap.ts"
 import { Vec3 } from "./general.ts"
 import { Regex } from "./regex.ts"
 
-export const QUEST_CUSTOMS_WIP_LEVELS_PATH =
-  "/sdcard/ModData/com.beatgames.beatsaber/Mods/SongLoader/CustomWIPLevels";
+export const QUEST_WIP_PATH =
+    "/sdcard/ModData/com.beatgames.beatsaber/Mods/SongLoader/CustomWIPLevels";
 
 // TODO: If possible, try to figure out a way to default to a string with no extension or path
 export type FILENAME<T extends string = string> = T | `${T}.${string}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,9 @@ import { Difficulty } from "./beatmap.ts"
 import { Vec3 } from "./general.ts"
 import { Regex } from "./regex.ts"
 
+export const QUEST_CUSTOMS_WIP_LEVELS_PATH =
+  "/sdcard/ModData/com.beatgames.beatsaber/Mods/SongLoader/CustomWIPLevels";
+
 // TODO: If possible, try to figure out a way to default to a string with no extension or path
 export type FILENAME<T extends string = string> = T | `${T}.${string}`;
 export type FILEPATH<T extends string = string> = FILENAME<T> | `${string}/${FILENAME<T>}`;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,4 +2,4 @@ export * as path from 'https://deno.land/std@0.140.0/path/mod.ts';
 export * as fs from 'https://deno.land/std@0.110.0/fs/mod.ts';
 export { compress } from "https://deno.land/x/zip@v1.2.3/mod.ts";
 export * as three from "https://cdn.skypack.dev/three?dts";
-export * as adbDeno from "https://deno.land/x/adb_deno@0.1.2/lib.ts";
+export * as adbDeno from "https://deno.land/x/adb_deno@0.1.4/lib.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,4 +2,4 @@ export * as path from 'https://deno.land/std@0.140.0/path/mod.ts';
 export * as fs from 'https://deno.land/std@0.110.0/fs/mod.ts';
 export { compress } from "https://deno.land/x/zip@v1.2.3/mod.ts";
 export * as three from "https://cdn.skypack.dev/three?dts";
-export * as adbDeno from "https://deno.land/x/adb_deno@0.1.1/lib.ts";
+export * as adbDeno from "https://deno.land/x/adb_deno@0.1.2/lib.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,3 +2,4 @@ export * as path from 'https://deno.land/std@0.140.0/path/mod.ts';
 export * as fs from 'https://deno.land/std@0.110.0/fs/mod.ts';
 export { compress } from "https://deno.land/x/zip@v1.2.3/mod.ts";
 export * as three from "https://cdn.skypack.dev/three?dts";
+export * as adbDeno from "https://deno.land/x/adb_deno@0.1.1/lib.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -13,4 +13,4 @@ export * from './regex.ts';
 export * from './light_remapper.ts';
 export * from './anim_optimizer.ts';
 export * from './model.ts';
-export { adbDeno, three } from "./deps.ts"
+export { adbDeno, three } from "./deps.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -13,3 +13,4 @@ export * from './regex.ts';
 export * from './light_remapper.ts';
 export * from './anim_optimizer.ts';
 export * from './model.ts';
+export { adbDeno, three } from "./deps.ts"


### PR DESCRIPTION
Not tested.

Files are expected to be uploaded to `QUEST_CUSTOMS_WIP_LEVELS_PATH` which as the name suggests, is the WIP song folder.

- expose adbDeno and three too
- add constant for Quest WIP folder

Usage:
```ts
/// works similar to exportToZip
export async function exportToQuest(excludeDiffs: FILENAME<DIFFS>[] = [], options?: InvokeADBOptions) {
```