### PR TITLE
Add 'Glowing' material to the GeoShader type definition

### DIFF
--- a/src/types/beatmap/object/environment.ts
+++ b/src/types/beatmap/object/environment.ts
@@ -57,6 +57,7 @@ export type GeoShader =
     | 'InterscopeCar'
     | 'Obstacle'
     | 'WaterfallMirror'
+    | 'Glowing'
 
 /** LightID used on lights and other lighting_v3 events. `ID | [ID, ID, ID]` */
 export type LightID = number | number[]


### PR DESCRIPTION
Beat Saber's 1.38 release broke the old keywordless Standard shader producing a fully-illuminated material. Chroma addressed this by introducing a dedicated Glowing material in February of 2025, which replicates the old behavior of Standard when used with no keywords. More info here: https://heck.aeroluna.dev/environment/environment/#material

What this means for RM is that we should have one more shader entry in GeoShader so that intellisense doesn't bark at you if you try to use Glowing :D